### PR TITLE
移除 app.js 对权限模块的引用

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,6 @@ import router from './router'
 import store from './store'
 
 import '@/icons' // icon
-import '@/permission' // permission control
 
 Vue.use(ElementUI, { locale })
 


### PR DESCRIPTION
看之前讨论的已经移除权限模块了，但是这里还有引用。